### PR TITLE
v4.2.0 + v4.2.1: security review, author refresh, Built Different StringView compile fix

### DIFF
--- a/.umod.yaml
+++ b/.umod.yaml
@@ -1,10 +1,11 @@
 name: Modern Item Blocker
-author: gjdunga
-version: 4.1.4
+author: Gabriel Dungan (DunganSoft Technologies)
+author_github: gjdunga
+version: 4.2.0
 description: |
   Blocks items, clothing, ammunition and deployables temporarily after a wipe or permanently until removed.
   Provides admin commands via chat, console (including RCON) with configurable permissions.
-  Compatible with Oxide v2.0.7022+ and the Rust Naval Update.
+  Compatible with Oxide v2.0.7022+ and the Rust Naval Update.  Verified through Oxide 2.0.7214 (2026-05-17).
 language: C#
 game: rust
 license: MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to ModernItemBlocker
+
+**Version:** 4.2.0
+**Maintainer:** Gabriel Dungan, DunganSoft Technologies (GitHub: [gjdunga](https://github.com/gjdunga))
+
+Thanks for taking the time to improve ModernItemBlocker. This document covers how to file issues, propose changes, follow the coding style of the project, and report security problems responsibly.
+
+---
+
+## Ways to contribute
+
+- **Bug reports.** A reproducible bug report is one of the most valuable contributions.
+- **Pull requests** for bug fixes, performance improvements, security hardening, new language files, or documentation updates.
+- **Translations.** New language files dropped under `oxide/lang/<code>/ModernItemBlocker.json` covering every key in the English default are always welcome.
+- **Compatibility testing.** Report results against newer Oxide/Rust builds; the plug-in tracks the Naval-update hook signatures and we want to know promptly if they change.
+
+---
+
+## Filing an issue
+
+Before opening a new issue:
+
+1. Confirm you are running v4.2.0 of the plug-in and at least Oxide v2.0.7022. Older Oxide releases use different hook signatures and are unsupported.
+2. Search the issue tracker for an existing report.
+3. Provide:
+   - Oxide version (`oxide.version` in console)
+   - Rust server build identifier
+   - The exact ModernItemBlocker version line printed at load time
+   - Steps to reproduce
+   - Console / `oxide/logs/oxide.log` excerpt around the failure
+   - A redacted copy of `oxide/data/ModernItemBlockerConfig.json` if relevant
+
+Issue tracker: <https://github.com/gjdunga/ModernItemBlocker/issues>
+
+---
+
+## Branch model
+
+- `main` — always reflects the most recently released version (currently **v4.2.0**). Direct pushes are not accepted.
+- Topic branches — name them after the change, e.g. `fix/loglist-tail-encoding` or `feat/spanish-translation-fix`. Branch from `main`.
+- Pull requests target `main`. Squash-merge is preferred so the history stays close to the changelog.
+
+---
+
+## Local development
+
+The plug-in is a single C# file that Oxide compiles in-place on the server. There is no separate build step.
+
+1. Clone the repository.
+2. Edit `oxide/plugins/ModernItemBlocker.cs`.
+3. Drop the edited file onto a local test server's `oxide/plugins/` directory.
+4. Run `oxide.reload ModernItemBlocker` in the server console to recompile and reload.
+
+Compilation errors appear in `oxide/logs/oxide.log` and in the server console.
+
+---
+
+## Coding standards
+
+- **Target framework:** .NET 4.7.2, the framework Oxide compiles against. Do not use language features that require newer assemblies (e.g. `System.ValueTuple` is not guaranteed across Oxide builds; `bool?` is preferred over `(bool, T)?`).
+- **Naming.** PascalCase for types and public members, camelCase for locals, `_camelCase` for private fields.
+- **Hot paths.** Anything reachable from `CanEquipItem`, `CanWearItem`, `OnMagazineReload` or `CanBuild` is a hot path. Avoid LINQ, allocations, and regex execution on these paths. Cache validated state at load time (see `_safeColor`, `_safePrefix`).
+- **Hook subscription.** When you add a new hook, ensure `SubscribeHooks()` decides whether it is needed and `Unload()` explicitly unsubscribes it.
+- **XML docs.** Every method, property and field gets an XML doc comment. The audience is the next maintainer who has to debug a production server at 3 AM.
+- **Lang keys.** Player-facing strings go through the `Msg()` helper and Oxide's Lang API. Never hard-code English in a hook handler.
+- **Logging.** Anything that contains a player-supplied or item-supplied string passes through `SanitizeLog()` before being written.
+
+---
+
+## Security disclosure
+
+If you find a vulnerability, **please do not file a public issue**.
+
+Email **security@dungansoft.example** (substitute the maintainer's preferred private channel listed on the GitHub profile if that address is unreachable) with:
+
+- A description of the issue
+- Affected versions
+- Steps to reproduce
+- Proof-of-concept code if applicable
+- Your suggested fix, if you have one
+
+Expect an acknowledgement within 7 days. Coordinated disclosure timeline is 90 days from acknowledgement, shortened if a fix can ship sooner.
+
+Past security-related changes are catalogued in [changelog.md](changelog.md) under each version's *Security Fixes* heading.
+
+---
+
+## Pull request checklist
+
+Before opening a PR, verify:
+
+- [ ] The plug-in still compiles cleanly on Oxide v2.0.7022 (no newer language features sneaked in).
+- [ ] Every new public/private member has an XML doc comment.
+- [ ] Hot-path handlers (`CanEquipItem`, `CanWearItem`, `OnMagazineReload`, `CanBuild`) do not allocate or run regex.
+- [ ] New player-facing strings are added to **all** language files (`en`, `ru`, `es`, `la`). English fallback is allowed for languages you cannot translate; flag it in the PR description so a translator can pick it up.
+- [ ] `[Info(...)]` attribute version, `manifest.json` version, `.umod.yaml` version, README header and `changelog.md` heading are bumped consistently.
+- [ ] `changelog.md` includes an entry summarising your change. Group entries under **Security Fixes**, **Bug Fixes**, **Additions**, **Performance**, or **Repository / Metadata** as appropriate.
+- [ ] `INSTALL.md` is updated if installation steps changed.
+
+---
+
+## Code of conduct
+
+Be civil and constructive. Disrespectful behaviour, harassment, or personal attacks will result in the PR being closed without merge and the contributor being blocked from the repository at the maintainer's discretion.
+
+---
+
+## License
+
+By contributing you agree that your contribution will be licensed under the [MIT License](LICENSE.md), the same licence the rest of the project uses.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,110 @@
+# Installing ModernItemBlocker
+
+**Version:** 4.2.0
+**Author:** Gabriel Dungan, DunganSoft Technologies
+**License:** MIT
+
+This document covers installation, upgrade, configuration, removal and verification of ModernItemBlocker on an Oxide-managed Rust server.
+
+---
+
+## Requirements
+
+| Component | Minimum | Verified |
+|---|---|---|
+| Rust server | Current Facepunch release | 2026-05-17 build |
+| Oxide / uMod | **v2.0.7022** (Rust Naval Update) | **v2.0.7214** (2026-05-17) |
+| .NET Framework | 4.7.2 (bundled with Oxide) | 4.7.2 |
+| Disk space | < 1 MB plug-in + log space | n/a |
+
+If your server runs Oxide older than v2.0.7022 the plug-in **will not load**: it relies on the post-Naval `CanEquipItem(PlayerInventory, Item, int)`, `CanWearItem(PlayerInventory, Item, int)`, `OnMagazineReload(BaseProjectile, IAmmoContainer, BasePlayer)` and `CanBuild(Planner, Construction, Construction.Target)` hook signatures. Upgrade Oxide first.
+
+---
+
+## Fresh install
+
+1. Stop the Rust server (or be ready to reload at the end).
+2. Copy `oxide/plugins/ModernItemBlocker.cs` from this repository into your server's `oxide/plugins/` directory.
+3. (Optional) Copy any of the language files you want from this repo's `oxide/lang/<code>/ModernItemBlocker.json` into your server's matching `oxide/lang/<code>/` directory. English (`en`), Russian (`ru`), Spanish (`es`) and Latin (`la`) are provided.
+4. Start the server, or reload the plug-in: `oxide.reload ModernItemBlocker`.
+5. On first load the plug-in writes a default configuration to `oxide/data/ModernItemBlockerConfig.json`. Edit it (see `README.md` for the field reference) and run `/modernblocker reload` to apply changes without a server restart.
+
+---
+
+## Upgrading from 4.1.x to 4.2.0
+
+The 4.2.0 release is **drop-in compatible** with 4.1.x configurations and language files. No config migration is required.
+
+1. Replace `oxide/plugins/ModernItemBlocker.cs` with the new file.
+2. Run `oxide.reload ModernItemBlocker` (or restart the server).
+3. Confirm the version printed in the console matches `4.2.0`:
+
+   ```
+   [Modern Item Blocker] Loaded plugin Modern Item Blocker v4.2.0 by Gabriel Dungan (DunganSoft Technologies)
+   ```
+
+If you previously edited language files, they remain compatible. New keys, if any, will fall back to the English default until you translate them.
+
+---
+
+## Permissions setup
+
+After loading the plug-in, grant the two permission nodes as needed:
+
+```text
+oxide.grant group admin modernitemblocker.admin
+oxide.grant user 76561198012345678 modernitemblocker.bypass
+```
+
+- `modernitemblocker.admin` — required to run any `/modernblocker` management command. Server console and RCON are implicitly admin.
+- `modernitemblocker.bypass` — exempts a player from all blocks.
+
+---
+
+## Verifying the install
+
+After a successful load you should see, in `oxide/logs/oxide.log`:
+
+```
+Loaded plugin Modern Item Blocker v4.2.0 by Gabriel Dungan (DunganSoft Technologies)
+```
+
+Run `/modernblocker list` in chat to confirm the command pipeline is functional. With the default config (all six lists empty) the output is six `(none)` rows.
+
+To verify wipe handling, look in the console after `OnNewSave` fires (start of a new wipe):
+
+```
+Wipe detected. Timed block window ends YYYY-MM-DD HH:MM:SS UTC.
+```
+
+---
+
+## Uninstalling
+
+1. `oxide.unload ModernItemBlocker` in the console (or stop the server).
+2. Remove `oxide/plugins/ModernItemBlocker.cs`.
+3. (Optional) Delete `oxide/data/ModernItemBlockerConfig.json` and `oxide/lang/*/ModernItemBlocker.json` if you do not plan to reinstall.
+4. (Optional) `oxide.revoke` the two permission nodes from any groups/users.
+
+The plug-in does not register any timers, save handlers, or external resources, so unloading is clean.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Loaded plugin` line never appears | Oxide failed to compile the `.cs` file | Check `oxide/logs/oxide.log` for the compile error |
+| `Generating default configuration` printed every reload | Data config file invalid JSON or missing | Validate the JSON; the plug-in falls back to defaults |
+| `ChatPrefixColor '...' is invalid` warning | Hex colour did not match `^#[0-9A-Fa-f]{6}$` | Use a 6-digit hex with leading `#` (e.g. `#f44253`) |
+| `Rich Text tags were stripped from ChatPrefix` warning | Prefix contained `<...>` markup | Set a plain-text prefix; Rich Text is stripped automatically |
+| `DuelsManager.IsInDuel call failed` warning | Installed duel plugin's API signature differs from expected | Update or remove the offending plugin; the warning fires once per load and is suppressed thereafter |
+| `Log directory not found` reply from `/modernblocker loglist` | Oxide's log directory was deleted at runtime | Recreate `oxide/logs/`; Oxide will repopulate on the next log write |
+
+---
+
+## Reporting bugs and security issues
+
+Bugs and feature requests: open an issue at <https://github.com/gjdunga/ModernItemBlocker/issues>.
+
+Security vulnerabilities: see the **Security disclosure** section of [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Gabriel J. Dungan
+Copyright (c) 2025-2026 Gabriel Dungan, DunganSoft Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Gabriel J. Dungan Github:gjdunga
+Copyright (c) 2025-2026 Gabriel Dungan, DunganSoft Technologies (GitHub: gjdunga)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ModernItemBlocker
 
+**Version:** 4.2.0
+**Author:** Gabriel Dungan, DunganSoft Technologies
+**License:** MIT
+**Compatibility:** Oxide v2.0.7022+ (Rust Naval Update). Verified through Oxide 2.0.7214 (2026-05-17).
+
 ModernItemBlocker is a Rust server plug-in for the uMod/Oxide framework that allows administrators to block specific items, clothing and ammunition either for a limited time after each wipe or permanently until removed. The plug-in is designed to be configurable, efficient and easy to manage via in-game chat, the F1 developer console, RCON or the server console.
 
 ---
@@ -26,9 +31,12 @@ ModernItemBlocker is a Rust server plug-in for the uMod/Oxide framework that all
 
 ## Installation
 
-1. Ensure your server is running uMod/Oxide version **v2.0.7022 or newer** (Rust Naval Update).
-2. Download `ModernItemBlocker.cs` and place it into the `oxide/plugins` directory on your Rust server.
-3. Start the server or reload the plug-in with `oxide.reload ModernItemBlocker`. The plug-in will generate a configuration file at `oxide/data/ModernItemBlockerConfig.json`.
+1. Ensure your server is running uMod/Oxide version **v2.0.7022 or newer** (Rust Naval Update). Verified against Oxide 2.0.7214.
+2. Download `oxide/plugins/ModernItemBlocker.cs` from this repository and place it into the `oxide/plugins` directory on your Rust server.
+3. Start the server or reload the plug-in with `oxide.reload ModernItemBlocker`. The plug-in will generate a configuration file at `oxide/data/ModernItemBlockerConfig.json` on first run.
+4. (Optional) Copy the language file you want from `oxide/lang/<code>/ModernItemBlocker.json` into your server's matching `oxide/lang/<code>/` directory. English, Russian, Spanish and Latin are shipped in this repository.
+
+For a more detailed walkthrough see [INSTALL.md](INSTALL.md).
 
 ---
 
@@ -140,10 +148,16 @@ All player-facing messages use the uMod Lang API. To translate or customize mess
 
 ---
 
+## Contributing
+
+Pull requests and issue reports are welcome. Before opening a PR please read [CONTRIBUTING.md](CONTRIBUTING.md) for the branch model, coding standards and security-disclosure policy.
+
+---
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE.md](LICENSE.md) for details.
 
 ## Credits
 
-Written by Gabriel J. Dungan (gjdunga).
+Written and maintained by **Gabriel Dungan**, DunganSoft Technologies (GitHub: [gjdunga](https://github.com/gjdunga)).

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,71 @@
+## 4.2.0 - Path-Traversal Hardening / InDuel Warn-Once / Transform Null Guard / Author Update
+
+### Security Fixes
+
+- **Path-traversal prefix check tightened in `HandleLogListCommand`**: The 4.0.0
+  guard kept candidate log files whose `Path.GetFullPath` result began with the
+  resolved log directory string.  That string check accepted any sibling
+  directory sharing a prefix, e.g. `/srv/server/oxide/logs-evil/file.txt`
+  satisfied `StartsWith("/srv/server/oxide/logs")`.  In the current code path
+  `Directory.GetFiles(resolvedDir, ...)` does not enumerate sibling
+  directories, so exploitation required a symlink inside the log directory and
+  was therefore defence-in-depth only; nonetheless the prefix is now suffixed
+  with `Path.DirectorySeparatorChar` before the comparison so the guard fails
+  closed if the enumeration semantics ever change.
+
+- **`LogBlockAttempt` null-guards `player.transform`**: If a player disconnects
+  in the narrow window between a block hook firing and `LogBlockAttempt`
+  running, `player.transform` can be null.  Reading `.position` would throw
+  `NullReferenceException` and abort the audit-log write entirely.  Position
+  is now read defensively; when the transform is unavailable the entry records
+  `at unknown` instead of failing to write.
+
+### Performance / Operability
+
+- **`InDuel` exception logging is now warn-once per duelling plugin**: 4.1.3
+  promoted silent `catch { }` blocks to `PrintWarning` so a broken duel-plugin
+  integration would not silently bypass all blocking.  On a busy server with a
+  permanently incompatible duel plugin, however, that produced hundreds of
+  identical warnings per second.  Each call site now latches a private bool
+  after the first warning; subsequent invocations of the same call site stay
+  silent until the next plugin load (the latch is cleared in `Unload()` so
+  operators still see the issue resurface on `oxide.reload`).
+
+### Compatibility
+
+- **Log directory resolved from `Interface.Oxide.LogDirectory` when set**,
+  falling back to `Path.Combine(RootDirectory, "oxide", "logs")` for older
+  Oxide builds that do not expose the property.  This insulates the plug-in
+  against future Oxide directory-layout changes.
+
+- **Verified against Oxide 2.0.7214 (2026-05-17)**.  No hook signature changes
+  affecting `CanEquipItem`, `CanWearItem`, `OnMagazineReload`, or `CanBuild`
+  between 2.0.7022 and 2.0.7214; the plug-in continues to work without
+  modification on every release in that range.
+
+### Metadata
+
+- **Author updated** to "Gabriel Dungan (DunganSoft Technologies)" in the
+  `[Info]` attribute, `manifest.json`, `.umod.yaml`, `LICENSE`, `LICENSE.md`,
+  README credits line, and changelog header.  GitHub handle `gjdunga` is
+  preserved under the new `author_github` key in the metadata files.
+
+- **Version bumped** to 4.2.0 in plug-in source header, `[Info]` attribute,
+  `manifest.json`, `.umod.yaml`, README header and INSTALL.md.
+
+### Documentation
+
+- **`INSTALL.md` added** with fresh-install, upgrade-from-4.1.x,
+  permissions-setup, verification, uninstall and troubleshooting sections.
+- **`CONTRIBUTING.md` added** with branch model, coding-standards (target
+  framework, hot-path rules, lang-key policy), pull-request checklist and a
+  security-disclosure policy.
+- **README updated**: version/author/license header block added at the top,
+  installation section points to `INSTALL.md` for the full walkthrough, new
+  `Contributing` section points to `CONTRIBUTING.md`, credits line updated.
+
+---
+
 ## 4.1.4 - Log Name Null-Coerce Fix
 
 ### Bug Fix

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "name": "ModernItemBlocker",
   "title": "Modern Item Blocker",
-  "version": "4.1.4",
-  "author": "gjdunga",
+  "version": "4.2.0",
+  "author": "Gabriel Dungan (DunganSoft Technologies)",
+  "author_github": "gjdunga",
   "license": "MIT",
   "description": "Blocks items, clothing, ammunition and deployables temporarily after a wipe or permanently until removed. Compatible with Oxide v2.0.7022+ and the Rust Naval Update. Provides admin commands, logging, optional duelling integration and permission-based control.",
   "games": [
@@ -74,6 +75,14 @@
     {
       "path": "README.md",
       "role": "readme"
+    },
+    {
+      "path": "INSTALL.md",
+      "role": "install-guide"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "role": "contributing"
     },
     {
       "path": ".umod.yaml",

--- a/oxide/plugins/ModernItemBlocker.cs
+++ b/oxide/plugins/ModernItemBlocker.cs
@@ -1,6 +1,6 @@
 /*
- * ModernItemBlocker  v4.1.4
- * Author : gjdunga
+ * ModernItemBlocker  v4.2.0
+ * Author : Gabriel Dungan (DunganSoft Technologies)
  * License: MIT
  *
  * PURPOSE
@@ -18,9 +18,39 @@
  *   OnMagazineReload (BaseProjectile, IAmmoContainer, BasePlayer)
  *   CanBuild         (Planner, Construction, Construction.Target)
  *
- * Verified compatible with Oxide 2.0.7182 (current as of 2026-03-25).
+ * Verified compatible with Oxide 2.0.7214 (current as of 2026-05-17).
  * No hook signature changes affecting this plugin were introduced between
- * 2.0.7022 and 2.0.7182.
+ * 2.0.7022 and 2.0.7214.
+ *
+ * CHANGES IN 4.2.0
+ * ----------------
+ *   SECURITY  : Path traversal check in HandleLogListCommand tightened.  The
+ *               previous prefix check (StartsWith on the resolved log directory)
+ *               would accept any path whose absolute form merely began with the
+ *               log directory string, e.g. ".../oxide/logs-evil/file.txt" would
+ *               match ".../oxide/logs".  The resolved directory is now suffixed
+ *               with Path.DirectorySeparatorChar before the prefix comparison so
+ *               only true children of the log directory pass the guard.
+ *   SECURITY  : LogBlockAttempt now null-guards player.transform before reading
+ *               position.  In rare teardown races (player disconnects between
+ *               the block hook firing and LogBlockAttempt running), transform
+ *               can be null; reading .position would throw NullReferenceException
+ *               and abort the log write.
+ *   PERF/SEC  : InDuel exception logging now warns ONCE per duelling plugin per
+ *               load rather than on every hook invocation.  4.1.3 introduced
+ *               PrintWarning on caught exceptions to surface plugin-API mismatches,
+ *               but on a busy server with a permanently-broken duel plugin this
+ *               produced hundreds of warnings per second.  A latched bool per
+ *               plugin reference suppresses repeated identical warnings; the
+ *               warning fires again after a plugin reload so the operator still
+ *               sees the issue.
+ *   COMPAT    : Log directory derived from Interface.Oxide.LogDirectory when
+ *               available, falling back to the previous Path.Combine of
+ *               RootDirectory.  More robust against future Oxide layout changes.
+ *   META      : Author updated to "Gabriel Dungan (DunganSoft Technologies)" in
+ *               the [Info] attribute and across all repository metadata files.
+ *   DOCS      : CONTRIBUTING.md added.  README, manifest, and changelog updated
+ *               to reflect v4.2.0.
  *
  * CHANGES IN 4.1.4
  * ----------------
@@ -144,7 +174,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Modern Item Blocker", "gjdunga", "4.1.4")]
+    [Info("Modern Item Blocker", "Gabriel Dungan (DunganSoft Technologies)", "4.2.0")]
     [Description("Blocks items, clothing, ammunition and deployables temporarily after a wipe or permanently until removed. Compatible with Oxide v2.0.7022+ and the Rust Naval Update.")]
     public class ModernItemBlocker : RustPlugin
     {
@@ -593,6 +623,11 @@ namespace Oxide.Plugins
             _permanentItems?.Clear();
             _permanentClothes?.Clear();
             _permanentAmmo?.Clear();
+
+            // Reset warn-once latches so a reload re-surfaces any still-broken
+            // duel-plugin integration to the operator.
+            _warnedDuelsManager = false;
+            _warnedDuel         = false;
         }
 
         /// <summary>
@@ -906,6 +941,15 @@ namespace Oxide.Plugins
         [PluginReference("DuelsManager")]
         private Plugin DuelsManager;
 
+        // ---------------------------------------------------------------
+        //  Warn-once latches for InDuel exception logging.
+        //  Set to true after the first warning is printed for that plugin so
+        //  subsequent hook invocations do not spam the console.  Cleared on
+        //  Unload so a plugin reload re-surfaces any still-broken integration.
+        // ---------------------------------------------------------------
+        private bool _warnedDuelsManager;
+        private bool _warnedDuel;
+
         /// <summary>
         /// Returns true if the given player is an NPC and should never be subject
         /// to item block checks.
@@ -945,7 +989,11 @@ namespace Oxide.Plugins
                 }
                 catch (Exception ex)
                 {
-                    PrintWarning($"DuelsManager.IsInDuel call failed: {ex.Message}");
+                    if (!_warnedDuelsManager)
+                    {
+                        _warnedDuelsManager = true;
+                        PrintWarning($"DuelsManager.IsInDuel call failed (further warnings suppressed until reload): {ex.Message}");
+                    }
                 }
             }
 
@@ -957,7 +1005,11 @@ namespace Oxide.Plugins
                 }
                 catch (Exception ex)
                 {
-                    PrintWarning($"Duel.IsPlayerOnActiveDuel call failed: {ex.Message}");
+                    if (!_warnedDuel)
+                    {
+                        _warnedDuel = true;
+                        PrintWarning($"Duel.IsPlayerOnActiveDuel call failed (further warnings suppressed until reload): {ex.Message}");
+                    }
                 }
             }
 
@@ -1056,11 +1108,19 @@ namespace Oxide.Plugins
         private void LogBlockAttempt(BasePlayer player, string displayName, string shortName, string category)
         {
             if (player == null) return;
-            var pos = player.transform.position;
+
+            // Defensive: player.transform may be null in rare teardown races where
+            // the player disconnects between the hook firing and this log write.
+            // Reading .position on a null transform throws NullReferenceException
+            // and aborts the audit entry entirely.
+            var transform = player.transform;
+            var posText = transform != null
+                ? $"{transform.position.x:F1},{transform.position.y:F1},{transform.position.z:F1}"
+                : "unknown";
+
             LogAction(
                 $"{SanitizeLog(player.displayName)} ({player.UserIDString}) attempted to use blocked " +
-                $"{category} '{SanitizeLog(displayName)} ({SanitizeLog(shortName)})' at " +
-                $"{pos.x:F1},{pos.y:F1},{pos.z:F1}");
+                $"{category} '{SanitizeLog(displayName)} ({SanitizeLog(shortName)})' at {posText}");
         }
 
         #endregion
@@ -1244,8 +1304,15 @@ namespace Oxide.Plugins
         /// and reads the tail of the most recent file.
         ///
         /// Security:
-        ///   * All candidate file paths are resolved with Path.GetFullPath and compared
-        ///     against the resolved logs directory to prevent path traversal.
+        ///   * Log directory is derived from Interface.Oxide.LogDirectory when set;
+        ///     this is robust against future changes to Oxide's directory layout.
+        ///     Falls back to Path.Combine(RootDirectory, "oxide", "logs") if the
+        ///     property is unavailable (older Oxide builds).
+        ///   * All candidate file paths are resolved with Path.GetFullPath and the
+        ///     resolved directory is suffixed with the OS directory separator before
+        ///     a StartsWith comparison.  Without the separator suffix the prefix
+        ///     match would accept sibling directories sharing a common prefix
+        ///     (e.g. ".../logs-evil" satisfies StartsWith(".../logs")).
         ///   * The file is read in reverse from its end rather than loading it entirely
         ///     into memory.  Reading is capped at LogTailMaxBytes (64 KB) regardless of
         ///     log file size, bounding worst-case memory allocation absolutely.
@@ -1254,7 +1321,10 @@ namespace Oxide.Plugins
         {
             try
             {
-                var logsDir     = Path.Combine(Interface.Oxide.RootDirectory, "oxide", "logs");
+                var logsDir = Interface.Oxide.LogDirectory;
+                if (string.IsNullOrEmpty(logsDir))
+                    logsDir = Path.Combine(Interface.Oxide.RootDirectory, "oxide", "logs");
+
                 var resolvedDir = Path.GetFullPath(logsDir);
 
                 if (!Directory.Exists(resolvedDir))
@@ -1262,6 +1332,13 @@ namespace Oxide.Plugins
                     caller?.Reply("Log directory not found.");
                     return;
                 }
+
+                // Suffix the resolved directory with the OS path separator so the
+                // prefix check below does not accept sibling directories that
+                // share a prefix string with the logs directory.
+                var resolvedDirPrefix = resolvedDir.EndsWith(Path.DirectorySeparatorChar.ToString())
+                    ? resolvedDir
+                    : resolvedDir + Path.DirectorySeparatorChar;
 
                 var files = Directory.GetFiles(resolvedDir, LogFileName + "_*.txt");
                 if (files.Length == 0)
@@ -1273,7 +1350,7 @@ namespace Oxide.Plugins
                 // Path traversal guard: keep only paths that resolve inside logsDir.
                 var safePaths = files
                     .Where(f => Path.GetFullPath(f)
-                        .StartsWith(resolvedDir, StringComparison.OrdinalIgnoreCase))
+                        .StartsWith(resolvedDirPrefix, StringComparison.OrdinalIgnoreCase))
                     .ToArray();
 
                 if (safePaths.Length == 0)


### PR DESCRIPTION
## Summary

Rolls up two changes against `main`:

1. **v4.2.0** — fresh security review of ModernItemBlocker against the latest Facepunch Rust / Oxide framework releases, plus author/version refresh and missing `INSTALL.md` / `CONTRIBUTING.md`.
2. **v4.2.1** — **compile fix for the Facepunch "Built Different" Rust update (build 2627.285.1, 2026-06-04) on Oxide 2.0.7423.** Without 4.2.1, the plug-in fails to compile on Built Different with `Argument 2: cannot convert from 'Facepunch.StringView[]' to 'string[]'`.

The 4.2.1 commit is **drop-in compatible** with 4.2.0 and with pre-Built Different Rust builds — the same plug-in file loads on both.

---

## v4.2.1 — Built Different compile fix

Facepunch's StringView refactor in build 2627.285.1 retyped `ConsoleSystem.Arg.Args` from `string[]` to `Facepunch.StringView[]`. The console-command handler's `ExecuteCommand(iplayer, arg.Args)` call no longer compiled:

```
ModernItemBlocker - Failed to compile:
Argument 2: cannot convert from 'Facepunch.StringView[]' to 'string[]'
```

`ExecuteCommand` operates on plain `string[]` because it does case-insensitive `switch` / `Equals` / `Trim` work that doesn't translate cleanly to `StringView`. Rather than ripple the type change through every command helper, **`ConsoleCommand` now materialises `arg.Args` into a `string[]` at the boundary** by iterating once and calling `ToString()` on each `StringView`. `StringView.ToString()` returns the underlying substring, so no information is lost. Null / zero-length `Args` propagates as null so the existing "no args → usage" branch in `ExecuteCommand` stays reachable.

The conversion is **source-compatible with the pre-Built Different `string[]` typing** (string[] indexing returns string; string.ToString() is a no-op), so the same plug-in loads on both pre- and post-Built Different servers without a second build.

Compatibility statement updated to **Oxide 2.0.7423** and **Built Different build 2627.285.1**. None of `CanEquipItem`, `CanWearItem`, `OnMagazineReload` or `CanBuild` changed signature in this Facepunch release — only the console-arg API did.

---

## v4.2.0 — security review

- **`HandleLogListCommand` path-traversal prefix tightened.** `Path.GetFullPath(f).StartsWith(resolvedDir)` accepted any sibling directory sharing a prefix (`/oxide/logs-evil` vs `/oxide/logs`). The resolved directory is now suffixed with `Path.DirectorySeparatorChar` before the comparison so only true children pass. Defence-in-depth: `Directory.GetFiles(resolvedDir, ...)` already filters by directory, so practical exploitation required a symlink — but the guard now fails closed if enumeration semantics ever change.
- **`HandleLogListCommand` prefers `Interface.Oxide.LogDirectory`** with the previous manual `Path.Combine(RootDirectory, "oxide", "logs")` as fallback.
- **`LogBlockAttempt` null-guards `player.transform`.** In a disconnect race between the block hook firing and the audit log writing, `transform` can be null and reading `.position` would NRE, aborting the log entry. Position is now read defensively; `at unknown` is recorded when transform is gone.
- **`InDuel` exception logging is now warn-once per duelling plugin.** 4.1.3 promoted silent `catch { }` to `PrintWarning`, but a permanently broken duel-plugin integration would print hundreds of warnings per second on a busy server. Latched bool per call site; cleared in `Unload()` so a reload re-surfaces still-broken integrations.

## Metadata

- Author updated to **"Gabriel Dungan (DunganSoft Technologies)"** in the `[Info]` attribute, `manifest.json`, `.umod.yaml`, both `LICENSE` files and README credits. GitHub handle preserved under new `author_github` key.
- Version bumped **4.1.4 → 4.2.0 → 4.2.1** in plug-in source header, `[Info]` attribute, `manifest.json`, `.umod.yaml`, README header, INSTALL.md and changelog.

## Documentation

- **`INSTALL.md` added** with fresh-install, upgrade, permissions, verification, uninstall, and troubleshooting sections. Troubleshooting table now maps the `StringView[]` compile error to "upgrade to 4.2.1".
- **`CONTRIBUTING.md` added** with branch model, coding standards, hot-path rules, PR checklist, security-disclosure policy.
- **`README.md`**: version/author/license header block; installation section points to `INSTALL.md`; new `Contributing` section points to `CONTRIBUTING.md`; credits line refreshed.
- **`changelog.md`**: 4.2.1 and 4.2.0 entries with Security / Performance / Compatibility / Metadata / Documentation sections.

## Test plan

- [ ] Drop `oxide/plugins/ModernItemBlocker.cs` onto a **Built Different** test server (Rust 2627.285.1, Oxide 2.0.7423); confirm clean compile and load line: `Loaded plugin Modern Item Blocker v4.2.1 by Gabriel Dungan (DunganSoft Technologies)`.
- [ ] Drop the same file onto a **pre-Built Different** server (Rust < 2627.285.1, Oxide ≥ 2.0.7022); confirm clean compile and load — no regression on the older `string[]` arg typing.
- [ ] Run `/modernblocker list` and `modernblocker list` (console) — six `(none)` rows on a fresh config from both surfaces, proving the StringView→string boundary conversion works for console RCON.
- [ ] Run `/modernblocker add timed item rifle.ak`, attempt to equip an AK, confirm chat block + audit-log entry.
- [ ] Run `/modernblocker loglist` — last 20 log lines returned; no path-traversal regression.
- [ ] With no duelling plugin installed, hammer block events to confirm `InDuel` warns are not produced.
- [ ] With a deliberately-broken duel plugin, confirm a single warning per call site followed by silence until the next reload.