### PR TITLE
v4.2.3: de/fr/pt/zh-CN translations (8 locales)

### DIFF
--- a/.github/workflows/draft-release-on-tag.yml
+++ b/.github/workflows/draft-release-on-tag.yml
@@ -33,8 +33,10 @@ jobs:
       - name: Stage language assets with unique names
         run: |
           mkdir -p release-assets
-          for loc in en ru es la; do
-            cp "oxide/lang/$loc/ModernItemBlocker.json" "release-assets/ModernItemBlocker-$loc.json"
+          for dir in oxide/lang/*/; do
+            loc="$(basename "$dir")"
+            src="${dir}ModernItemBlocker.json"
+            [ -f "$src" ] && cp "$src" "release-assets/ModernItemBlocker-${loc}.json"
           done
 
       - name: Create draft release
@@ -47,10 +49,7 @@ jobs:
           files: |
             oxide/plugins/ModernItemBlocker.cs
             oxide/data/ModernItemBlockerConfig.json
-            release-assets/ModernItemBlocker-en.json
-            release-assets/ModernItemBlocker-ru.json
-            release-assets/ModernItemBlocker-es.json
-            release-assets/ModernItemBlocker-la.json
+            release-assets/ModernItemBlocker-*.json
             README.md
             INSTALL.md
             CONTRIBUTING.md

--- a/.umod.yaml
+++ b/.umod.yaml
@@ -1,7 +1,7 @@
 name: Modern Item Blocker
 author: Gabriel Dungan (DunganSoft Technologies)
 author_github: gjdunga
-version: 4.2.2
+version: 4.2.3
 description: |
   Blocks items, clothing, ammunition and deployables temporarily after a wipe or permanently until removed.
   Provides admin commands via chat, console (including RCON) with configurable permissions.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installing ModernItemBlocker
 
-**Version:** 4.2.2
+**Version:** 4.2.3
 **Author:** Gabriel Dungan, DunganSoft Technologies
 **License:** MIT
 
@@ -48,10 +48,10 @@ To upgrade:
 
 1. Replace `oxide/plugins/ModernItemBlocker.cs` with the new file.
 2. Run `oxide.reload ModernItemBlocker` (or restart the server).
-3. Confirm the version printed in the console matches `4.2.2`:
+3. Confirm the version printed in the console matches `4.2.3`:
 
    ```
-   [Modern Item Blocker] Loaded plugin Modern Item Blocker v4.2.2 by gjdunga
+   [Modern Item Blocker] Loaded plugin Modern Item Blocker v4.2.3 by gjdunga
    ```
 
 If you previously edited language files, they remain compatible. New keys, if any, will fall back to the English default until you translate them.
@@ -77,7 +77,7 @@ oxide.grant user 76561198012345678 modernitemblocker.bypass
 After a successful load you should see, in `oxide/logs/oxide.log`:
 
 ```
-Loaded plugin Modern Item Blocker v4.2.2 by gjdunga
+Loaded plugin Modern Item Blocker v4.2.3 by gjdunga
 ```
 
 Run `/modernblocker list` in chat to confirm the command pipeline is functional. With the default config (all six lists empty) the output is six `(none)` rows.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ModernItemBlocker
 
-**Version:** 4.2.2
+**Version:** 4.2.3
 **Author:** Gabriel Dungan, DunganSoft Technologies
 **License:** MIT
 **Compatibility:** Oxide v2.0.7022+ (Rust Naval Update). Verified through Oxide 2.0.7423 and the Facepunch "Built Different" Rust update (build 2627.285.1, 2026-06-04).

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+## 4.2.3 - Full localization (8 locales)
+
+### Localization
+- Added German (`de`), French (`fr`), Portuguese (`pt`) and Simplified Chinese
+  (`zh-CN`) translations. The plugin now ships all eight locales: `en`, `es`, `ru`,
+  `la`, `zh-CN`, `de`, `fr`, `pt`. Placeholders (`{0}`–`{5}`, `{1:00}` time fields),
+  `\n` line breaks, and `/modernblocker` command literals are preserved in every
+  locale.
+
+### CI
+- `draft-release-on-tag.yml` now stages and attaches **all** locale files via a glob
+  instead of a hardcoded four, so future locales are included automatically.
+
+No gameplay, configuration, hook, or data-format changes.
+
 ## 4.2.2 - uMod submission prep & compile chain
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "ModernItemBlocker",
   "title": "Modern Item Blocker",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "author": "Gabriel Dungan (DunganSoft Technologies)",
   "author_github": "gjdunga",
   "license": "MIT",

--- a/oxide/lang/de/ModernItemBlocker.json
+++ b/oxide/lang/de/ModernItemBlocker.json
@@ -1,0 +1,16 @@
+{
+  "ItemBlocked": "Du kannst diesen Gegenstand nicht verwenden.",
+  "ClothBlocked": "Du kannst dieses Kleidungsstück nicht anlegen.",
+  "AmmoBlocked": "Du kannst diese Munition nicht verwenden.",
+  "BuildBlocked": "Du kannst diesen Gegenstand nicht platzieren.",
+  "TimedSuffix": "\n{0}T {1:00}:{2:00}:{3:00} bis zur Freigabe verbleibend.",
+  "PermanentSuffix": "\nDieser Gegenstand ist dauerhaft gesperrt, bis ein Administrator ihn entfernt.",
+  "NotAllowed": "Du hast keine Berechtigung, diesen Befehl zu verwenden.",
+  "InvalidArgs": "Ungültige Syntax. Verwende /modernblocker help für Details.",
+  "NameTooLong": "Gegenstandsname ist zu lang (max. 256 Zeichen).",
+  "Added": "'{0}' zur Liste {1} {2} hinzugefügt.",
+  "Removed": "'{0}' aus der Liste {1} {2} entfernt.",
+  "NotFound": "'{0}' wurde in der Liste {1} {2} nicht gefunden.",
+  "ListHeader": "Dauerhaft gesperrte Gegenstände: {0}\nDauerhaft gesperrte Kleidung: {1}\nDauerhaft gesperrte Munition: {2}\nZeitlich gesperrte Gegenstände: {3}\nZeitlich gesperrte Kleidung: {4}\nZeitlich gesperrte Munition: {5}",
+  "Usage": "Verwendung:\n /modernblocker list\n /modernblocker add <permanent|timed> <item|cloth|ammo> <n>\n /modernblocker remove <permanent|timed> <item|cloth|ammo> <n>\n /modernblocker reload\n /modernblocker loglist"
+}

--- a/oxide/lang/fr/ModernItemBlocker.json
+++ b/oxide/lang/fr/ModernItemBlocker.json
@@ -1,0 +1,16 @@
+{
+  "ItemBlocked": "Vous ne pouvez pas utiliser cet objet.",
+  "ClothBlocked": "Vous ne pouvez pas porter ce vêtement.",
+  "AmmoBlocked": "Vous ne pouvez pas utiliser ces munitions.",
+  "BuildBlocked": "Vous ne pouvez pas déployer cet objet.",
+  "TimedSuffix": "\n{0}j {1:00}:{2:00}:{3:00} restant avant le déblocage.",
+  "PermanentSuffix": "\nCet objet est bloqué en permanence jusqu'à ce qu'un administrateur le retire.",
+  "NotAllowed": "Vous n'avez pas la permission d'utiliser cette commande.",
+  "InvalidArgs": "Syntaxe invalide. Utilisez /modernblocker help pour plus de détails.",
+  "NameTooLong": "Le nom de l'objet est trop long (max. 256 caractères).",
+  "Added": "'{0}' ajouté à la liste {1} {2}.",
+  "Removed": "'{0}' retiré de la liste {1} {2}.",
+  "NotFound": "'{0}' introuvable dans la liste {1} {2}.",
+  "ListHeader": "Objets bloqués en permanence : {0}\nVêtements bloqués en permanence : {1}\nMunitions bloquées en permanence : {2}\nObjets bloqués temporairement : {3}\nVêtements bloqués temporairement : {4}\nMunitions bloquées temporairement : {5}",
+  "Usage": "Utilisation :\n /modernblocker list\n /modernblocker add <permanent|timed> <item|cloth|ammo> <n>\n /modernblocker remove <permanent|timed> <item|cloth|ammo> <n>\n /modernblocker reload\n /modernblocker loglist"
+}

--- a/oxide/lang/pt/ModernItemBlocker.json
+++ b/oxide/lang/pt/ModernItemBlocker.json
@@ -1,0 +1,16 @@
+{
+  "ItemBlocked": "Você não pode usar este item.",
+  "ClothBlocked": "Você não pode vestir esta peça de roupa.",
+  "AmmoBlocked": "Você não pode usar esta munição.",
+  "BuildBlocked": "Você não pode posicionar este item.",
+  "TimedSuffix": "\n{0}d {1:00}:{2:00}:{3:00} restantes até o desbloqueio.",
+  "PermanentSuffix": "\nEste item está bloqueado permanentemente até que um administrador o remova.",
+  "NotAllowed": "Você não tem permissão para usar este comando.",
+  "InvalidArgs": "Sintaxe inválida. Use /modernblocker help para detalhes.",
+  "NameTooLong": "O nome do item é muito longo (máx. 256 caracteres).",
+  "Added": "'{0}' adicionado à lista {1} {2}.",
+  "Removed": "'{0}' removido da lista {1} {2}.",
+  "NotFound": "'{0}' não foi encontrado na lista {1} {2}.",
+  "ListHeader": "Itens bloqueados permanentemente: {0}\nRoupas bloqueadas permanentemente: {1}\nMunições bloqueadas permanentemente: {2}\nItens bloqueados temporariamente: {3}\nRoupas bloqueadas temporariamente: {4}\nMunições bloqueadas temporariamente: {5}",
+  "Usage": "Uso:\n /modernblocker list\n /modernblocker add <permanent|timed> <item|cloth|ammo> <n>\n /modernblocker remove <permanent|timed> <item|cloth|ammo> <n>\n /modernblocker reload\n /modernblocker loglist"
+}

--- a/oxide/lang/zh-CN/ModernItemBlocker.json
+++ b/oxide/lang/zh-CN/ModernItemBlocker.json
@@ -1,0 +1,16 @@
+{
+  "ItemBlocked": "你不能使用此物品。",
+  "ClothBlocked": "你不能穿戴此服装。",
+  "AmmoBlocked": "你不能使用此弹药。",
+  "BuildBlocked": "你不能放置此物品。",
+  "TimedSuffix": "\n距离解锁还有 {0}天 {1:00}:{2:00}:{3:00}。",
+  "PermanentSuffix": "\n此物品被永久封禁，直到管理员将其移除。",
+  "NotAllowed": "你没有权限使用此命令。",
+  "InvalidArgs": "语法无效。使用 /modernblocker help 查看详情。",
+  "NameTooLong": "物品名称过长（最多 256 个字符）。",
+  "Added": "已将 '{0}' 添加到 {1} {2} 列表。",
+  "Removed": "已从 {1} {2} 列表中移除 '{0}'。",
+  "NotFound": "在 {1} {2} 列表中未找到 '{0}'。",
+  "ListHeader": "永久封禁物品：{0}\n永久封禁服装：{1}\n永久封禁弹药：{2}\n限时封禁物品：{3}\n限时封禁服装：{4}\n限时封禁弹药：{5}",
+  "Usage": "用法：\n /modernblocker list\n /modernblocker add <permanent|timed> <item|cloth|ammo> <n>\n /modernblocker remove <permanent|timed> <item|cloth|ammo> <n>\n /modernblocker reload\n /modernblocker loglist"
+}

--- a/oxide/plugins/ModernItemBlocker.cs
+++ b/oxide/plugins/ModernItemBlocker.cs
@@ -1,5 +1,5 @@
 /*
- * ModernItemBlocker  v4.2.2
+ * ModernItemBlocker  v4.2.3
  * Author : gjdunga (Gabriel Dungan, DunganSoft Technologies)
  * License: MIT
  *
@@ -205,7 +205,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Modern Item Blocker", "gjdunga", "4.2.2")]
+    [Info("Modern Item Blocker", "gjdunga", "4.2.3")]
     [Description("Blocks items, clothing, ammunition and deployables temporarily after a wipe or permanently until removed. Compatible with Oxide v2.0.7022+ and the Rust Naval Update.")]
     public class ModernItemBlocker : RustPlugin
     {


### PR DESCRIPTION
Adds German, French, Portuguese and Simplified Chinese translations (placeholders + `/modernblocker` literals preserved) — now 8 locales. Also makes `draft-release-on-tag.yml` glob all locale files (was hardcoded to 4). Lang-only; compiles clean against Oxide 2.0.7423.