### PR TITLE
docs: regenerate Codefling listing (signing verify section)

### DIFF
--- a/CODEFLING.md
+++ b/CODEFLING.md
@@ -45,6 +45,17 @@ Blocks items, clothing, ammunition and deployables temporarily after a wipe or p
 2. Upload it to `oxide/plugins/ModernItemBlocker.cs` on your server.
 3. The plugin compiles and loads automatically; a default config is written to `oxide/config/ModernItemBlocker.json` on first load.
 
+## Verifying the download
+
+This plugin is **code-signed**. Every release attaches a detached OpenPGP signature (`ModernItemBlocker.cs.asc`) and the public key (`gjdunga.asc`):
+
+```bash
+gpg --import gjdunga.asc   # fingerprint EAC0A2AE65CC6C9762DD6AF06877843761D5C6E6
+gpg --verify ModernItemBlocker.cs.asc ModernItemBlocker.cs
+```
+
+Expect: `Good signature from "Gabriel Dungan <gjdunga@gmail.com>"`.
+
 ## What's new in 4.2.6
 
 ### Changed


### PR DESCRIPTION
Regenerates `CODEFLING.md` via the updated `make-listing.py` to add the **Verifying the download** section now that releases are code-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)